### PR TITLE
speculative execution

### DIFF
--- a/src/app/lab1_supersup.erl
+++ b/src/app/lab1_supersup.erl
@@ -23,14 +23,6 @@ init([]) ->
 	    type => supervisor, 
 		modules => [lab1_worker_sup]
 	},
-    Router = #{
-		id => lab1_router,
-	    start => {lab1_router, start_link, []}, 
-		restart => permanent,
-	    shutdown => 2000, 
-		type => worker, 
-		modules => [lab1_router]
-	},
     Scaler = #{
 		id => lab1_scaler,
 	    start => {lab1_scaler, start_link, []}, 
@@ -38,6 +30,14 @@ init([]) ->
 	    shutdown => 2000, 
 		type => worker, 
 		modules => [lab1_scaler]
+	},
+    Router = #{
+		id => lab1_router_spec,
+	    start => {lab1_router_spec, start_link, []}, 
+		restart => permanent,
+	    shutdown => 2000, 
+		type => worker, 
+		modules => [lab1_router_spec]
 	},
     Stream1 = "/tweets/1",
     Collector1 = #{id => lab1_collector1,
@@ -50,5 +50,6 @@ init([]) ->
 	      restart => permanent, shutdown => 2000, type => worker,
 	      modules => [lab1_collector]},
 
-    ChildSpecs = [WorkerSup, Router, Scaler, Collector1, Collector2],
+    ChildSpecs = [WorkerSup, Router, Collector1],
+    % ChildSpecs = [WorkerSup, Scaler, Router, Collector1, Collector2],
     {ok, {SupFlags, ChildSpecs}}.

--- a/src/components/lab1_collector.erl
+++ b/src/components/lab1_collector.erl
@@ -7,10 +7,10 @@ start(Stream) ->
     Options = #{
         async => true, 
         async_mode => sse,
-        handle_event => fun (_, _, Tweet) -> lab1_router:route(Tweet) end
+        handle_event => fun (_, _, Tweet) -> lab1_router_spec:route(Tweet) end
     },
     {ok, _Ref} = shotgun:get(Conn, Stream, #{}, Options),
-    wait(100000),
+    wait(150),
     shotgun:close(Conn),
     {ok, self()}.
 

--- a/src/components/lab1_router_spec.erl
+++ b/src/components/lab1_router_spec.erl
@@ -1,0 +1,90 @@
+-module(lab1_router_spec).
+-behaviour(gen_server).
+
+-export([start_link/0, init/1, route/1, done/1, handle_call/3, handle_cast/2, handle_info/2, handle_continue/2]).
+
+-define(WORKER_SUP, lab1_worker_sup).
+-define(SCALER, lab1_scaler).
+-define(RETRYTIME, 100).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    timer:sleep(1000),
+    io:format("~p: ~p~n", ["Router Spec", self()]),
+
+    WorkerPids = lists:map(
+        fun({_, WorkerPid, _, _}) ->
+            {WorkerPid, false}
+        end, 
+        supervisor:which_children(?WORKER_SUP)
+    ),
+    Workers = maps:from_list(WorkerPids),
+    {ok, {Workers}}.
+
+route(Tweet) ->
+    gen_server:cast(?MODULE, {tweet, Tweet}),
+    gen_server:cast(?MODULE, {tweet, Tweet}),
+    gen_server:cast(?MODULE, {tweet, Tweet}).
+
+done(Tweet) ->
+    gen_server:cast(?MODULE, {done, Tweet}).
+
+
+handle_call(_, _, _State) ->
+    {noreply, _State}.
+
+handle_cast({tweet, Tweet}, {Workers}) ->
+    {noreply, {Workers}, {continue, {tweet, Tweet}}};
+
+handle_cast({done, Tweet}, {Workers}) ->
+    % Find Workers working with Tweet; Free them
+    FreedWorkers = maps:filtermap(
+        fun(_, Value) when Value == Tweet ->
+            {true, false};
+        (_, _) ->
+            false
+        end, 
+        Workers
+    ),
+
+    NewWorkers = maps:merge(Workers, FreedWorkers),
+    {noreply, {NewWorkers}}.
+
+handle_continue({tweet, Tweet}, {Workers}) ->    
+    % Find free worker
+    WorkerPid = free_worker(Workers),
+    continue(Workers, Tweet, WorkerPid).
+
+handle_info({timeout, _, Tweet}, {Workers}) ->
+    {noreply, {Workers}, {continue, {tweet, Tweet}}}.
+
+
+continue(Workers, Tweet, false) ->
+    erlang:start_timer(?RETRYTIME, self(), Tweet),
+    {noreply, {Workers}};
+continue(Workers, Tweet, WorkerPid) ->
+    % Route Tweet to Worker
+    gen_server:cast(WorkerPid, Tweet),
+
+    % Mark Worker as busy
+    NewWorkers = maps:update(WorkerPid, Tweet, Workers),
+    {noreply, {NewWorkers}}.    
+
+free_worker(Workers) ->
+    FreeWorkers = maps:filter(
+        fun(_, false) ->
+            true;
+        (_, _) ->
+            false
+        end, 
+        Workers
+    ),
+    free(FreeWorkers, maps:size(FreeWorkers)).
+
+free(_, 0) ->
+    false;
+free(Workers, _) ->
+    [Head | _] = maps:keys(Workers),
+    Head.

--- a/src/components/lab1_scaler.erl
+++ b/src/components/lab1_scaler.erl
@@ -31,7 +31,7 @@ handle_info({timeout, _, _}, State) ->
     WorkerPids = supervisor:which_children(?WORKER_SUP),
     TotalWorkers = length(WorkerPids),
 
-    NrWorkers = RunningAvg div 100 - TotalWorkers + 3,
+    NrWorkers = RunningAvg div 100 - TotalWorkers + 10,
     io:format("~p: ~p requests per second. Scaling ~p worker(s).~n", ["Scaler", PerSecond, NrWorkers]),
     
     scale_pool(NrWorkers),

--- a/src/components/lab1_task.erl
+++ b/src/components/lab1_task.erl
@@ -1,0 +1,24 @@
+-module(lab1_task).
+-behaviour(gen_server).
+
+-export([start_link/1, init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+start_link([Tweet, TaskNr, MSec, WorkerPid]) -> 
+    gen_server:start_link(?MODULE, [Tweet, TaskNr, MSec, WorkerPid], []).
+
+init([Tweet, TaskNr, MSec, WorkerPid]) -> 
+    % io:format("~p: ~p~n", ["Task", self()]),
+
+    erlang:start_timer(MSec, self(), timeout),
+    {ok, {Tweet, MSec, TaskNr, WorkerPid}}.
+
+
+handle_call(_, _, _State) ->
+    {noreply, _State}.
+
+handle_cast(_, _State) ->
+    {noreply, _State}.
+
+handle_info({_, _, timeout}, {_Tweet, MSec, TaskNr, WorkerPid}) ->
+    io:format("Worker ~p Task number: ~p, time: ~p~n", [WorkerPid, TaskNr, MSec]),
+    {stop, shutdown, {}}.

--- a/src/components/lab1_worker_spec.erl
+++ b/src/components/lab1_worker_spec.erl
@@ -1,0 +1,38 @@
+-module(lab1_worker_spec).
+-behaviour(gen_server).
+
+-export([start_link/0, init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+start_link() -> 
+    gen_server:start_link(?MODULE, [], []).
+
+init([]) -> 
+    % io:format("~p: ~p~n", ["Worker Spec", self()]),
+    Prob = rand:uniform(),
+    case Prob < 0.05 of
+        true -> MSec = 10000;
+        false -> MSec = round(2900 * rand:uniform() + 100)
+    end,
+    {ok, {self(), false, 0, MSec}}.
+
+
+handle_call(_, _, _State) ->
+    {noreply, _State}.
+
+handle_cast(Tweet, {TaskPid, _, TaskNr, MSec}) ->
+    stop_if_alive(TaskPid, erlang:is_process_alive(TaskPid)),  
+    {ok, {NewTaskPid, _}} = gen_server:start_monitor(lab1_task, [Tweet, TaskNr, MSec, self()], []),
+    {noreply, {NewTaskPid, Tweet, TaskNr + 1, MSec}}.
+
+handle_info({_, _, _, _, normal}, {TaskPid, Tweet, TaskNr, MSec}) ->
+    {noreply, {TaskPid, Tweet, TaskNr, MSec}};
+handle_info({_, _, _, _, shutdown}, {TaskPid, Tweet, TaskNr, MSec}) ->
+    lab1_router_spec:done(Tweet),
+    {noreply, {TaskPid, Tweet, TaskNr, MSec}}.
+
+stop_if_alive(Pid, true) when Pid =/= self() ->
+    gen_server:stop(Pid);
+stop_if_alive(Pid, true) when Pid == self() ->
+    ok;
+stop_if_alive(_, false) ->
+    ok.

--- a/src/components/lab1_worker_sup.erl
+++ b/src/components/lab1_worker_sup.erl
@@ -16,12 +16,15 @@ init([]) ->
         period => MaxTime
     },
     Worker = #{
-        id => lab1_worker,
-        start => {lab1_worker, start_link, []}, 
+        id => lab1_worker_spec,
+        start => {lab1_worker_spec, start_link, []}, 
         restart => permanent,
         shutdown => 2000, 
         type => worker
     },
+
+    spawn_link(fun first_children/0),
+
     {ok, {SupFlags, [Worker]}}.
 
 start_worker() ->
@@ -29,3 +32,13 @@ start_worker() ->
 
 stop_worker(WorkerPid) ->
     supervisor:terminate_child(?MODULE, WorkerPid).
+
+
+first_children() ->
+    lists:map(
+        fun(_) ->
+            start_worker()
+        end,
+        lists:seq(1,100)
+    ),
+    ok.

--- a/src/components/start.txt
+++ b/src/components/start.txt
@@ -1,0 +1,23 @@
+
+worker5:start_link().
+
+gen_server:cast(<0.91.0>, "Hi").
+
+
+
+c(lab1_worker_spec).
+c(lab1_task).
+
+lab1_worker_spec:start_link().
+lab1_worker_spec:start_link().
+
+c(lab1_router_spec).
+lab1_router_spec:start_link().
+
+lab1_router_spec:route("Hi").
+lab1_router_spec:route("Hii").
+lab1_router_spec:route("Hiii").
+lab1_router_spec:route("Hiiii").
+lab1_router_spec:route("Hiiiii").
+
+lab1_router_spec:done("Hi").


### PR DESCRIPTION
Lab 1 with speculative execution. I've implemented a special case of speculative execution, which is cloning. When cloning, we duplicate with no speculation time, thus we send the tasks immediately to several workers. This helps in reducing the latency (time for processing a request) in our system, so that it takes less time to respond to requests. However, throughput (nr of requests processed per amount of time) is reduced bcs workers need to sometimes execute tasks which they eventually will not finish, since other workers finished them sooner, thus their work becomes invalid.

First example is without speculative execution, all the slow workers (last ones) have the chance to actually finish the task assigned to them, which is why the task number is 0 or 1, meaning each worker received their task and weren't given any other. This affects latency. With cloning, many workers are interrupted in their task execution when another worker has already finished the task faster, hence the higher task numbers.

video link:
https://utm-my.sharepoint.com/:v:/g/personal/daniela_palamari_isa_utm_md/EUGuyAthS_hPizyhehJV528B4yxowr9U3tcigGSZ2YfzOg?e=vf7cqt